### PR TITLE
Week 3 Patch Notes

### DIFF
--- a/basketball_rules.txt
+++ b/basketball_rules.txt
@@ -1,10 +1,9 @@
 1.Teams
-   a. Teams shuffle per week; Evenly divide the Dragon Balls 
+   a. Teams shuffle per week; Evenly divide a team's Dragon Balls between each team member. If uneven, figure it out.
    b. Battles are Team vs. Team unless they are out of office. Remaining team member can take extra shots to compensate.
-   c. Teams can have one member die instead of losing a Dragon Ball. Remaining team member(s) do NOT get extra shots to compensate.
 
 2.Scoring
-   a. Fire: keep shooting past max as long as you keep making it.
+   a. The Volley Ball Technique - One opponent is allowed 3 taps per shot to try and tap the ball into the goal for 0.5 points. Ball is dead after 3 taps / goal / touches a mostly horizontal surface (ie. ground/desk). Cannot force BP to play alone.
    b. Punished if you lose to a PERFECT from at least one opponent.
 
 3.Challenges
@@ -12,18 +11,18 @@
    b. You don’t have to accept after the 2nd daily challenge, but you can.
    c. Max N Dragon Ball(s) offered per fight, where N == Week #, Starting at 1 on Nov 20
 
-4.Usable if alive, each team starts each week with:
-   a. 3 Saves – Works like Rolando’s.
+4.Usable if alive, each player starts each week with:
+   a. 2 Saves – Works like Rolando’s.
    b. 1 KS – Save that can kill. Optionally call “Kill Steal” to take the rewards of winning the fight from the rightful winner. Teams can chain KS’s.
  
 5.Maritza
-   If Maritza is hit while a majority of her body is in her cubicle, -1 point for the perpetrator. If the rebounder doesn’t try to rebound “normally,” then they lose the point instead if she’s hit.
+   If Maritza is hit or startled, every player in the current match gets on their knees (as much as possible), bows, and begs for forgiveness. 
 
 6.Win Condition: Tournament of Power
    a. All players participate as single players
    b. Free for all challenges
    c. Saves/KS are legal. (Spend 3 saves to do a 1v2)
    d. Victory - At least one member of the “Lead” team remains, everyone else is knocked out
-   e. Defeat – The “Lead” team is knocked out, and the remaining players play for two of the “Lead” team’s Dragon Balls. 
+   e. Defeat – The “Lead” team is knocked out. The remaining players fight until there are 2 players remaining, and award 1 Dragon Ball to each player. (If there is 1 player left their team gets both).
 
 7. Rules can change at the start of the week.

--- a/basketball_rules.txt
+++ b/basketball_rules.txt
@@ -9,7 +9,7 @@
 3.Challenges
    a. Each team has 1 daily forced challenge.
    b. You don’t have to accept after the 2nd daily challenge, but you can.
-   c. Max N Dragon Ball(s) offered per fight, where N == Week #, Starting at 1 on Nov 20
+   c. Max 2 Dragon Ball(s) offered per fight
 
 4.Usable if alive, each player starts each week with:
    a. 2 Saves – Works like Rolando’s.


### PR DESCRIPTION
**Sharing is Caring**
-Many players seemed confused about evenly dividing Dragon Balls, thinking that it would reset the game back to default. An errata has been made to this rule for clarification.

> Teams shuffle per week; Evenly divide a team's Dragon Balls between each team member. If uneven, figure it out.

**Watch me, Tienshinhan**
-This week's special house rule is a throwback to the good ol' days of Dragon Ball. It has been previously brought up that some players might not find this rule as palpable as Fire, but rest assured the team is aware of this and have made changes to make it a little more fair.

> The Volley Ball Technique - One opponent is allowed 3 taps per shot to try and tap the ball into the goal for 0.5 points. Ball is dead after 3 taps / goal / touches a mostly horizontal surface (ie. ground/desk). Cannot force BP to play alone.

[Watch the Legend](https://www.youtube.com/watch?v=3rDFgimCHAU)

**Who needs Kakarot when I can save you!?**
-Some players have expressed a dislike for sharing resources with their team. As such, each player will be given their own set of resources going forward, while the number of saves given each player has been reduced to compensate.

> Nerf: Only 2 Saves
> Buff: Each member gets 2 Saves + 1 KS

**I sincerely apologize, Stalinzka.**
-Our moderators noticed some flaming and unsportsmanlike conduct from a certain team of players with the initials RH and BJ. To prevent future baby crying and to promote the spirit of protecting our friend Stalinzka, every player in a match will be equally at fault for causing harm to fly her way. We're sorry!

> Removed: -1 Punishment for hitting Stalinzka
> Added: If Stalinzka is hit or startled, every player in the current match gets on their knees (as much as possible), bows, and begs for forgiveness. 

**This isn't about justice. It's about survival.**
The team wanted there to be more incentive for teams to fight amongst themselves during the Tournament of Power, alone with keeping the Dragon Balls more spread out if the leaders are pushed out of the ring. As such, the final 2 players keep Dragon Balls, so you better make sure your partner survives (or you take out the leading team) if you want 2 Dragon Balls!

> The remaining players fight until there are 2 players remaining, and award 1 Dragon Ball to each player. (If there is 1 player left their team gets both).